### PR TITLE
ts-react: copy `.gitignore` file

### DIFF
--- a/src/ts-react/index.ts
+++ b/src/ts-react/index.ts
@@ -51,6 +51,11 @@ export default class extends Generator {
         superb: superb.random(),
       },
     );
+
+    this.fs.copy(
+      this.templatePath("root/.gitignore"),
+      this.destinationPath(".gitignore"),
+    );
   }
 
   end(): void {


### PR DESCRIPTION
Dotfiles are ignored when copying with glob pattern and must be
specifically targeted.