### PR TITLE
ts-react: fix h5p content type ts type

### DIFF
--- a/src/ts-react/templates/root/H5P.d.ts
+++ b/src/ts-react/templates/root/H5P.d.ts
@@ -2,7 +2,7 @@ import { H5PWrapper } from "./src/h5p/H5PWrapper";
 
 export interface H5PObject {
   EventDispatcher: typeof EventDispatcher;
-  <%= titlePascalCase %>: H5PWrapper;
+  <%= titlePascalCase %>: typeof H5PWrapper;
 }
 
 declare class EventDispatcher {


### PR DESCRIPTION
`H5P.MyContentType` should point to the class itself, not an instance
of the class.