### PR TITLE
ts-react: add typings for `H5PWrapper`

### DIFF
--- a/__tests__/ts-react.ts
+++ b/__tests__/ts-react.ts
@@ -15,7 +15,7 @@ describe(`generator-${generatorName}:${generator}`, () => {
         isEditor: false,
       })
       .withPrompts({
-        shouldAddStorybook: false,
+        useStorybook: false,
       });
 
     // The files can be added all in the same

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,7 +6,8 @@ const config: Config.InitialOptions = {
     ".(js|jsx)": "babel-jest",
     ".(ts|tsx)": "ts-jest"
   },
-  testPathIgnorePatterns: ["generators/", "templates/"]
+  testPathIgnorePatterns: ["generators/", "templates/"],
+  modulePathIgnorePatterns: ["generators/", "templates/"]
 };
 
 export default config;

--- a/src/ts-react/templates/root/H5P.d.ts
+++ b/src/ts-react/templates/root/H5P.d.ts
@@ -66,3 +66,16 @@ declare class EventDispatcher {
     external?: boolean;
   }) => void;
 }
+
+<% if (isEditor) { %>
+declare interface IH5PEditorWrapper {
+  appendTo($wrapper: JQuery<HTMLElement>): void;
+  validate(): boolean;
+  remove(): void;
+}
+<% } %>
+<% if (!isEditor) { %>
+declare interface IH5PWrapper {
+  attach($wrapper: JQuery<HTMLElement>): void;
+}
+<% } %>

--- a/src/ts-react/templates/root/package.json
+++ b/src/ts-react/templates/root/package.json
@@ -11,6 +11,10 @@
     "build:dev": "webpack --mode=development",
     "build:prod": "webpack --mode=production",
     "start": "webpack serve --hot --mode=development",
+    <% if (useStorybook) { %>
+    "storybook": "start-storybook -p 6006",
+    "build-storybook": "build-storybook",
+    <% } %>
     "test": "jest"
   },
   "dependencies": {
@@ -23,6 +27,14 @@
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
     "@hot-loader/react-dom": "^17.0.1+4.13.0",
+    <% if (useStorybook) { %>
+    "@storybook/addon-actions": "^6.3.7",
+    "@storybook/addon-essentials": "^6.3.7",
+    "@storybook/addon-links": "^6.3.7",
+    "@storybook/builder-webpack5": "^6.3.7",
+    "@storybook/manager-webpack5": "^6.3.7",
+    "@storybook/react": "^6.3.7",
+    <% } %>
     "@types/jquery": "^3.5.6",
     "@types/react": "^17.0.19",
     "@types/react-dom": "^17.0.9",

--- a/src/ts-react/templates/root/src/h5p/H5PEditorWrapper.tsx
+++ b/src/ts-react/templates/root/src/h5p/H5PEditorWrapper.tsx
@@ -1,23 +1,35 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import { IH5PWrapper } from "../../H5P";
+import { IH5PEditorWrapper } from "../../H5P";
 import App from "../App";
 import { H5P } from "./H5P.util";
 
-export class H5PWrapper extends H5P.EventDispatcher implements IH5PWrapper {
+export class H5PWrapper extends H5P.EventDispatcher
+  implements IH5PEditorWrapper {
   private wrapper: HTMLElement;
 
-  constructor(params: unknown, contentId: string, extras?: unknown) {
+  constructor(
+    parent: JQuery<HTMLElement>,
+    field: unknown,
+    params: unknown,
+    setValue: (value: unknown) => void
+  ) {
     super();
     this.wrapper = H5PWrapper.createWrapperElement();
 
     ReactDOM.render(<App adjective="<%= superb %>" />, this.wrapper);
   }
 
-  attach([containerElement]: JQuery<HTMLElement>) {
+  appendTo([containerElement]: JQuery<HTMLElement>): void {
     containerElement.appendChild(this.wrapper);
     containerElement.classList.add("h5p-<%= titleKebabCase %>");
   }
+
+  validate(): boolean {
+    return true;
+  }
+
+  remove(): void {}
 
   private static createWrapperElement(): HTMLDivElement {
     return document.createElement("div");


### PR DESCRIPTION
It has come to my attention that the "regular" and editor wrapper files are quite different, so I split them into two different templates.